### PR TITLE
Support Noise (Other Channel)

### DIFF
--- a/code_schemes/s01e04.json
+++ b/code_schemes/s01e04.json
@@ -173,6 +173,15 @@
       "VisibleInCoda": true
     },
     {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
       "CodeID": "code-NR-5e3eee23",
       "CodeType": "Control",
       "ControlCode": "NR",

--- a/code_schemes/s01e05.json
+++ b/code_schemes/s01e05.json
@@ -133,6 +133,15 @@
       "VisibleInCoda": true
     },
     {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
       "CodeID": "code-NR-5e3eee23",
       "CodeType": "Control",
       "ControlCode": "NR",

--- a/generate_outputs.py
+++ b/generate_outputs.py
@@ -103,6 +103,10 @@ if __name__ == "__main__":
         log.info("Applying Manual Codes from Coda...")
         data = ApplyManualCodes.apply_manual_codes(user, data, prev_coded_dir_path)
 
+        log.info("Filtering out Messages labelled as Noise_Other_Channel...")
+        data = MessageFilters.filter_noise_other_channel(
+            data, PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS)
+
         log.info("Generating Analysis CSVs...")
         messages_data, individuals_data = AnalysisFile.generate(user, data, csv_by_message_output_path,
                                                                 csv_by_individual_output_path)


### PR DESCRIPTION
Added to episodes 4+5 only for now, as these are the affected episodes. Will add to the remaining for next week if this is working well.

NOC code is adapted from WUSC-KEEP-II. The main significant change has been adapting it for a pipeline which supports running in auto-code mode only, as WUSC doesn't support this. On WUSC the strategy is to generate the production file after applying the manual codes. Since that doesn't work for an auto-code/full-run set-up, this is currently set to produce the production file before running the noise filter, but happy to discuss.