### PR TITLE
Trigger Demogs to non-noise participants

### DIFF
--- a/generate_outputs.py
+++ b/generate_outputs.py
@@ -1,5 +1,7 @@
 import argparse
+import json
 
+from core_data_modules.cleaners import Codes
 from core_data_modules.logging import Logger
 from core_data_modules.traced_data.io import TracedDataJsonIO
 from core_data_modules.util import IOUtils
@@ -44,6 +46,9 @@ if __name__ == "__main__":
     parser.add_argument("production_csv_output_path", metavar="production-csv-output-path",
                         help="Path to a CSV file to write raw message and demographic responses to, for use in "
                              "radio show production"),
+    parser.add_argument("demog_safe_uuids_output_path", metavar="demog-safe-uuids-output-path",
+                        help="Path to a JSON file to write the avf-uuids that are safe to send demographics messages "
+                             "to. These are individuals who don't have the label NR, NM, NCT, NOC, escalate, or STOP")
 
     args = parser.parse_args()
 
@@ -62,6 +67,7 @@ if __name__ == "__main__":
     csv_by_message_output_path = args.csv_by_message_output_path
     csv_by_individual_output_path = args.csv_by_individual_output_path
     production_csv_output_path = args.production_csv_output_path
+    demog_safe_uuids_output_path = args.demog_safe_uuids_output_path
 
     # Load the pipeline configuration file
     log.info("Loading Pipeline Configuration File...")
@@ -110,6 +116,33 @@ if __name__ == "__main__":
         log.info("Generating Analysis CSVs...")
         messages_data, individuals_data = AnalysisFile.generate(user, data, csv_by_message_output_path,
                                                                 csv_by_individual_output_path)
+
+        log.info("Finding uuids it is safe to send demogs to...")
+        demog_safe_uuids = []
+        # It's safe to send to anyone who isn't labelled as escalate, noise, NR, or STOP.
+        # Check the RQA messages only because we can make a decision based on the first messages that come in
+        # (and people who sent noise shouldn't have demog responses to check anyway).
+        for td in individuals_data:
+            print(td["uid"])
+            if td["consent_withdrawn"] == Codes.TRUE:
+                continue
+
+            safe = True
+            for plan in PipelineConfiguration.RQA_CODING_PLANS:
+                for cc in plan.coding_configurations:
+                    for label in td[cc.coded_field]:
+                        code = cc.code_scheme.get_code_with_code_id(label["CodeID"])
+                        if code.control_code in {"NM", "NCT", "NOC", "NR"} or code.meta_code in {"escalate"}:
+                            print(cc.coded_field, code.control_code, code.meta_code)
+                            safe = False
+
+            if safe:
+                demog_safe_uuids.append(td["uid"])
+        log.info(f"Found {len(demog_safe_uuids)} individuals it is safe to send demogs to, "
+                 f"out of {len(individuals_data)} total individuals")
+        log.info(f"Writing demog safe uuids to {demog_safe_uuids_output_path}...")
+        with open(demog_safe_uuids_output_path, "w") as f:
+            json.dump(demog_safe_uuids, f, indent=2)
 
         log.info("Writing messages TracedData to file...")
         IOUtils.ensure_dirs_exist_for_file(messages_json_output_path)

--- a/generate_outputs.py
+++ b/generate_outputs.py
@@ -123,7 +123,6 @@ if __name__ == "__main__":
         # Check the RQA messages only because we can make a decision based on the first messages that come in
         # (and people who sent noise shouldn't have demog responses to check anyway).
         for td in individuals_data:
-            print(td["uid"])
             if td["consent_withdrawn"] == Codes.TRUE:
                 continue
 
@@ -133,7 +132,6 @@ if __name__ == "__main__":
                     for label in td[cc.coded_field]:
                         code = cc.code_scheme.get_code_with_code_id(label["CodeID"])
                         if code.control_code in {"NM", "NCT", "NOC", "NR"} or code.meta_code in {"escalate"}:
-                            print(cc.coded_field, code.control_code, code.meta_code)
                             safe = False
 
             if safe:

--- a/run_scripts/3_generate_outputs.sh
+++ b/run_scripts/3_generate_outputs.sh
@@ -46,4 +46,4 @@ cd ..
     "$DATA_ROOT/Outputs/messages_traced_data.jsonl" "$DATA_ROOT/Outputs/individuals_traced_data.jsonl" \
     "$DATA_ROOT/Outputs/ICR/" "$DATA_ROOT/Outputs/Coda Files/" \
     "$DATA_ROOT/Outputs/messages.csv" "$DATA_ROOT/Outputs/individuals.csv" \
-    "$DATA_ROOT/Outputs/production.csv"
+    "$DATA_ROOT/Outputs/production.csv" "$DATA_ROOT/Outputs/demog_safe_uuids.json"

--- a/trigger_undp_kenya_s01_demog.py
+++ b/trigger_undp_kenya_s01_demog.py
@@ -88,4 +88,4 @@ if __name__ == "__main__":
         log.debug(urn)
         # (The API supports sending up to 100 URNs at once. This code opts to send one at a time, which is slower but
         #  keeps the code simple and makes it easier to debug by preventing partial successes/failures)
-        # rapid_pro.rapid_pro.create_flow_start(flow_id, urns=[urn], restart_participants=False)
+        rapid_pro.rapid_pro.create_flow_start(flow_id, urns=[urn], restart_participants=False)

--- a/trigger_undp_kenya_s01_demog.py
+++ b/trigger_undp_kenya_s01_demog.py
@@ -1,0 +1,91 @@
+import argparse
+import json
+
+from core_data_modules.logging import Logger
+from dateutil.parser import isoparse
+from id_infrastructure.firestore_uuid_table import FirestoreUuidTable
+from rapid_pro_tools.rapid_pro_client import RapidProClient
+from storage.google_cloud import google_cloud_utils
+
+from src.lib import PipelineConfiguration
+
+log = Logger(__name__)
+
+rapid_pro_domain = "textit.in"
+rapid_pro_token_url = "gs://avf-credentials/covid19-2-text-it-token.txt"
+demog_flow_name = "undp_kenya_s01_demog"
+demogs_attempted_variable = "undp_kenya_s01_demogs_attempted"
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Triggers demogs to people who haven't yet received them")
+
+    parser.add_argument("google_cloud_credentials_file_path", metavar="google-cloud-credentials-file-path",
+                        help="Path to a Google Cloud service account credentials file to use to access the "
+                             "credentials bucket")
+    parser.add_argument("pipeline_configuration_file_path", metavar="pipeline-configuration-file",
+                        help="Path to the pipeline configuration json file")
+    parser.add_argument("avf_uuid_file_path", metavar="avf-uuid-file-path",
+                        help="Domain that the first workspace of Rapid Pro is running on")
+
+    args = parser.parse_args()
+
+    google_cloud_credentials_file_path = args.google_cloud_credentials_file_path
+    pipeline_configuration_file_path = args.pipeline_configuration_file_path
+    avf_uuid_file_path = args.avf_uuid_file_path
+
+    log.info("Loading Pipeline Configuration File...")
+    with open(pipeline_configuration_file_path) as f:
+        pipeline_configuration = PipelineConfiguration.from_configuration_file(f)
+    Logger.set_project_name(pipeline_configuration.pipeline_name)
+    log.debug(f"Pipeline name is {pipeline_configuration.pipeline_name}")
+
+    log.info("Downloading Rapid Pro access token...")
+    rapid_pro_token = google_cloud_utils.download_blob_to_string(
+        google_cloud_credentials_file_path, rapid_pro_token_url).strip()
+
+    rapid_pro = RapidProClient(rapid_pro_domain, rapid_pro_token)
+
+    log.info("Downloading Firestore UUID Table credentials...")
+    firestore_uuid_table_credentials = json.loads(google_cloud_utils.download_blob_to_string(
+        google_cloud_credentials_file_path,
+        pipeline_configuration.phone_number_uuid_table.firebase_credentials_file_url
+    ))
+
+    phone_number_uuid_table = FirestoreUuidTable(
+        pipeline_configuration.phone_number_uuid_table.table_name,
+        firestore_uuid_table_credentials,
+        "avf-phone-uuid-"
+    )
+    log.info("Initialised the Firestore UUID table")
+
+    log.info(f"Loading the uuids that are safe to send to")
+    with open(avf_uuid_file_path) as f:
+        safe_uuids = json.load(f)
+    log.info(f"Loaded {len(safe_uuids)} uuids")
+
+    log.info(f"Re-identifying the uuids")
+    safe_numbers = phone_number_uuid_table.uuid_to_data_batch(safe_uuids).values()
+    safe_urns = {f"tel:+{number}" for number in safe_numbers}
+    log.info(f"Re-identified {len(safe_urns)} uuids")
+
+    log.info("Downloading the latest contacts fields from Rapid Pro")
+    contacts = rapid_pro.get_raw_contacts()
+    urn_to_contact = dict()
+    for c in contacts:
+        for urn in c.urns:
+            urn_to_contact[urn] = c
+
+    log.info(f"Filtering the urns who haven't received demogs before")
+    urns_to_send_to = {urn for urn in safe_urns
+                       if urn_to_contact[urn].fields[demogs_attempted_variable] is None
+                       and urn_to_contact[urn].created_on > isoparse("2020-10-07T00:00+00:00")}
+    log.info(f"Filtered for {len(urns_to_send_to)}/{len(safe_urns)} urns")
+
+    log.info(f"Triggering the demog flow for {len(urns_to_send_to)} safe URNs who haven't received demog questions yet")
+    flow_id = rapid_pro.get_flow_id(demog_flow_name)
+    for i, urn in enumerate(urns_to_send_to):
+        log.info(f"Triggering {i + 1}/{len(urns_to_send_to)}...")
+        log.debug(urn)
+        # (The API supports sending up to 100 URNs at once. This code opts to send one at a time, which is slower but
+        #  keeps the code simple and makes it easier to debug by preventing partial successes/failures)
+        # rapid_pro.rapid_pro.create_flow_start(flow_id, urns=[urn], restart_participants=False)


### PR DESCRIPTION
This project is being overwhelmed by messages from people who aren't trying to participate in our programming. We are arguably encouraging people to continue responding by immediately responding to those people with demogs.

This PR lets us mitigate that by allowing us to disable the automatic demog replies while still letting us send them to people who send a relevant message (at a cost to response rate), by:

- Updating the generate_outputs stage to export a list of uuids that it's safe to send demogs to. An individual is considered safe if none of their RQAs are labelled NR, Noise, or escalate, and if they didn't opt-out.
- Adding a new trigger_undp_kenya_s01_demog.py script that triggers demogs for everyone in that list of uuids who hasn't received the demog questions yet.

I've tested everything but the last line of trigger_undp_kenya_s01_demog.py over the full dataset, and the last line in test against our Experimental instance. I'd like to co-pilot the first full run of this on live data.