### PR TITLE
Set project end date

### DIFF
--- a/configuration/pipeline_config.json
+++ b/configuration/pipeline_config.json
@@ -150,7 +150,7 @@
     {"RapidProKey": "Age (Time) - undp_kenya_s01_demog", "PipelineKey": "age_time"}
   ],
   "ProjectStartDate": "2020-10-11T00:00:00+03:00",
-  "ProjectEndDate": "2100-01-01T00:00:00+03:00",
+  "ProjectEndDate": "2021-01-07T24:00:00+03:00",
   "FilterTestMessages": true,
   "MoveWSMessages": true,
   "AutomatedAnalysis": {


### PR DESCRIPTION
Set to the date on which the short code was deactivated according to the traffic dashboard, primarily for documentation purposes as the short code is now deactivated.